### PR TITLE
Add arm v7 architecture for image generation.

### DIFF
--- a/.github/workflows/build-yarr-docker.yml
+++ b/.github/workflows/build-yarr-docker.yml
@@ -40,7 +40,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/yarr:latest


### PR DESCRIPTION
Hello,

I was looking for a Docker image with Yarr and found yours. Big thanks for your work! I'd love to contribute the code for ARM v7 as I'm using a Raspi 3 at home and right now you don't build an image for this architecture.

Another question: What about publishing images also on Github? If you wish, I can add this in another commit. 